### PR TITLE
Remove boolean restrictions from parameter interface

### DIFF
--- a/src/Parameters/Parameter.php
+++ b/src/Parameters/Parameter.php
@@ -28,7 +28,7 @@ class Parameter implements ParameterInterface
     /**
      * @inheritdoc
      */
-    public function validate(string $input): bool
+    public function validate(string $input)
     {
         return ($this->validationClosure)($input);
     }

--- a/src/Parameters/ParameterInterface.php
+++ b/src/Parameters/ParameterInterface.php
@@ -14,7 +14,7 @@ interface ParameterInterface
     /**
      * @param string $input
      *
-     * @return bool
+     * @return mixed
      */
-    public function validate(string $input): bool;
+    public function validate(string $input);
 }


### PR DESCRIPTION
This allows parameters to return data other than a boolean, allowing them to convert string data into objects once again. This was a regression and unwanted restriction.